### PR TITLE
Errors at syntax check, not warnings. BMP-730 BMP-732

### DIFF
--- a/migration.go
+++ b/migration.go
@@ -35,10 +35,11 @@ func (m *Migration) String() string {
 
 // Up runs an up migration.
 func (m *Migration) Up(db *sql.DB) error {
+	fmt.Print(filepath.Base(m.Source), " ")
 	if err := m.run(db, true); err != nil {
 		return err
 	}
-	fmt.Println("OK   ", filepath.Base(m.Source))
+	fmt.Println("OK")
 	return nil
 }
 

--- a/migration_sql.go
+++ b/migration_sql.go
@@ -115,11 +115,11 @@ func getSQLStatements(r io.Reader, direction bool) (stmts []string, tx bool) {
 
 	// diagnose likely migration script errors
 	if ignoreSemicolons {
-		log.Println("WARNING: saw '-- +goose StatementBegin' with no matching '-- +goose StatementEnd'")
+		log.Fatalf("ERROR: saw '-- +goose StatementBegin' with no matching '-- +goose StatementEnd'")
 	}
 
 	if bufferRemaining := strings.TrimSpace(buf.String()); len(bufferRemaining) > 0 {
-		log.Printf("WARNING: Unexpected unfinished SQL query: %s. Missing a semicolon?\n", bufferRemaining)
+		log.Fatalf("ERROR: Unexpected unfinished SQL query: %s. Missing a semicolon?\n", bufferRemaining)
 	}
 
 	if upSections == 0 && downSections == 0 {


### PR DESCRIPTION
Задачи: https://mc2soft.myjetbrains.com/youtrack/issue/BMP-730 и https://mc2soft.myjetbrains.com/youtrack/issue/BMP-732
Суть: при некоторых синтаксических ошибках в SQL миграций, они успешно накатывались с warning'ом. Заменил на ошибки, и добавил вывод имени миграции до ее накатывания (т.к. в случае ошибки, непонятно было, при накатывании какой миграции они возникли).